### PR TITLE
Revert " IOAccessTime and IOMergerTime statistics overlap (#19342)"

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -40,6 +40,7 @@ func Backup(
 	bs *tree.BackupStart,
 	cfg *Config,
 ) error {
+	// test for export-test
 	var err error
 	var s3Conf *s3Config
 	if !cfg.metasMustBeSet() {

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -41,6 +41,7 @@ func Backup(
 	cfg *Config,
 ) error {
 	// test for export-test
+	// 2
 	var err error
 	var s3Conf *s3Config
 	if !cfg.metasMustBeSet() {

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -299,13 +299,6 @@ func (l *LocalFS) write(ctx context.Context, vector IOVector) (bytesWritten int,
 }
 
 func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
-	// Record diskIO IO and netwokIO(un memory IO) time Consumption
-	stats := statistic.StatsInfoFromContext(ctx)
-	ioStart := time.Now()
-	defer func() {
-		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
-	}()
-
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -320,6 +313,8 @@ func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
 	if len(vector.Entries) == 0 {
 		return moerr.NewEmptyVectorNoCtx()
 	}
+
+	stats := statistic.StatsInfoFromContext(ctx)
 
 	for _, cache := range vector.Caches {
 
@@ -365,6 +360,13 @@ read_memory_cache:
 			metric.FSReadDurationUpdateMemoryCache.Observe(time.Since(t0).Seconds())
 		}()
 	}
+
+	// Record diskIO and netwokIO(un memory IO) resource
+	ioStart := time.Now()
+	defer func() {
+		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
+	}()
+
 read_disk_cache:
 	if l.diskCache != nil {
 

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -288,16 +288,13 @@ func (s *S3FS) StatFile(ctx context.Context, filePath string) (*DirEntry, error)
 }
 
 func (s *S3FS) PrefetchFile(ctx context.Context, filePath string) error {
+
 	path, err := ParsePathAtService(filePath, s.name)
 	if err != nil {
 		return err
 	}
 
 	startLock := time.Now()
-	defer func() {
-		statistic.StatsInfoFromContext(ctx).AddS3FSPrefetchFileIOMergerTimeConsumption(time.Since(startLock))
-	}()
-
 	done, _ := s.ioMerger.Merge(IOMergeKey{
 		Path: filePath,
 	})
@@ -307,6 +304,7 @@ func (s *S3FS) PrefetchFile(ctx context.Context, filePath string) error {
 		// not wait in prefetch, return
 		return nil
 	}
+	statistic.StatsInfoFromContext(ctx).AddS3FSPrefetchFileIOMergerTimeConsumption(time.Since(startLock))
 
 	// load to disk cache
 	if s.diskCache != nil {
@@ -319,6 +317,7 @@ func (s *S3FS) PrefetchFile(ctx context.Context, filePath string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -436,13 +435,6 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) (bytesWritten int, er
 }
 
 func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
-	// Record S3 IO and netwokIO(un memory IO) time Consumption
-	stats := statistic.StatsInfoFromContext(ctx)
-	ioStart := time.Now()
-	defer func() {
-		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
-	}()
-
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -514,6 +506,13 @@ read_memory_cache:
 			metric.FSReadDurationUpdateMemoryCache.Observe(time.Since(t0).Seconds())
 		}()
 	}
+
+	// Record diskIO and netwokIO(un memory IO) resource
+	stats := statistic.StatsInfoFromContext(ctx)
+	ioStart := time.Now()
+	defer func() {
+		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
+	}()
 
 read_disk_cache:
 	if s.diskCache != nil {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2951,7 +2951,6 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 
 		statsInfo.Reset()
 		//average parse duration
-		statsInfo.ParseStartTime = beginInstant
 		statsInfo.ParseDuration = time.Duration(ParseDuration.Nanoseconds() / int64(len(cws)))
 
 		tenant := ses.GetTenantNameWithStmt(stmt)
@@ -3575,10 +3574,9 @@ func (h *marshalPlanHandler) Stats(ctx context.Context, ses FeSession) (statsByt
 		val := int64(statsByte.GetTimeConsumed()) + statsInfo.BuildReaderDuration +
 			int64(statsInfo.ParseDuration+
 				statsInfo.CompileDuration+
-				statsInfo.PlanDuration) -
-			(statsInfo.IOAccessTimeConsumption + statsInfo.S3FSPrefetchFileIOMergerTimeConsumption)
+				statsInfo.PlanDuration) - (statsInfo.IOAccessTimeConsumption + statsInfo.IOMergerTimeConsumption())
 		if val < 0 {
-			ses.Infof(ctx, "negative cpu statement_id:%s, statement_type:%s, statsInfo(%d + %d + %d + %d + %d -%d - %d) = %d",
+			ses.Infof(ctx, "negative cpu statement_id:%s, statement_type:%s, statsInfo(%d + %d + %d + %d + %d - %d - %d) = %d",
 				uuid.UUID(h.stmt.StatementID).String(),
 				h.stmt.StatementType,
 				int64(statsByte.GetTimeConsumed()),
@@ -3587,7 +3585,7 @@ func (h *marshalPlanHandler) Stats(ctx context.Context, ses FeSession) (statsByt
 				statsInfo.CompileDuration,
 				statsInfo.PlanDuration,
 				statsInfo.IOAccessTimeConsumption,
-				statsInfo.S3FSPrefetchFileIOMergerTimeConsumption,
+				statsInfo.IOMergerTimeConsumption(),
 				val)
 			v2.GetTraceNegativeCUCounter("cpu").Inc()
 		} else {

--- a/pkg/sql/compile/analyze_module.go
+++ b/pkg/sql/compile/analyze_module.go
@@ -483,7 +483,7 @@ func explainGlobalResources(queryResult *util.RunResult, statsInfo *statistic.St
 			cpuTimeVal := gblStats.TimeConsumed + statsInfo.BuildReaderDuration +
 				int64(statsInfo.ParseDuration+
 					statsInfo.CompileDuration+
-					statsInfo.PlanDuration) - (statsInfo.IOAccessTimeConsumption + statsInfo.S3FSPrefetchFileIOMergerTimeConsumption)
+					statsInfo.PlanDuration) - (statsInfo.IOAccessTimeConsumption + statsInfo.IOMergerTimeConsumption())
 
 			buffer.WriteString(fmt.Sprintf("StatsInfo：CpuTime(%dns) = PhyTime(%d)+BuildReaderTime(%d)+ParseTime(%d)+CompileTime(%d)+PlanTime(%d)-IOAccessTime(%d)-IOMergeTime(%d)\n",
 				cpuTimeVal,
@@ -493,7 +493,7 @@ func explainGlobalResources(queryResult *util.RunResult, statsInfo *statistic.St
 				statsInfo.CompileDuration,
 				statsInfo.PlanDuration,
 				statsInfo.IOAccessTimeConsumption,
-				statsInfo.S3FSPrefetchFileIOMergerTimeConsumption))
+				statsInfo.IOMergerTimeConsumption()))
 
 			buffer.WriteString(fmt.Sprintf("PlanStatsDuration: %dns, PlanResolveVariableDuration: %dns\n",
 				statsInfo.BuildPlanStatsDuration,

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -274,13 +274,12 @@ type StatsInfo struct {
 	//S3ReadBytes             uint
 	//S3WriteBytes            uint
 
-	// Local FileService blocking wait IOMerge time Consumption, which is included in IOAccessTimeConsumption
+	// Local FileService blocking wait time
 	LocalFSReadIOMergerTimeConsumption int64
-	// S3 FileService blocking wait IOMerge time Consumption, which is included in IOAccessTimeConsumption
-	S3FSReadIOMergerTimeConsumption int64
 
-	// S3 FileService Prefetch File IOMerge time Consumption
+	// S3 FileService blocking wait time
 	S3FSPrefetchFileIOMergerTimeConsumption int64
+	S3FSReadIOMergerTimeConsumption         int64
 
 	ParseStartTime     time.Time `json:"ParseStartTime"`
 	PlanStartTime      time.Time `json:"PlanStartTime"`


### PR DESCRIPTION
This reverts commit 02f9382184275649f0d6decee8bb40f71f5964c2.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: